### PR TITLE
UHF-10255: Add X-Robots-Tag if environment variable is set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,11 @@
         "drupal/helfi_azure_fs": "^2.0",
         "drupal/helfi_drupal_tools": "dev-main",
         "drupal/helfi_platform_config": "^4.0",
-        "drupal/helfi_proxy": "^2.0",
         "drupal/helfi_tunnistamo": "^2.0",
+        "drupal/purge": "^3.0",
         "drupal/raven": "^5.0",
         "drupal/stage_file_proxy": "^2.1",
+        "drupal/varnish_purge": "^2.1",
         "drush/drush": "^12"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e743eba7232c145e97f280d663efcc3c",
+    "content-hash": "7bdd5d17d866ccf76d0170bd8dce0eb6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4119,47 +4119,6 @@
                 "issues": "https://github.com/City-of-Helsinki/drupal-helfi-platform-config/issues"
             },
             "time": "2024-06-19T10:04:46+00:00"
-        },
-        {
-            "name": "drupal/helfi_proxy",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-proxy.git",
-                "reference": "cae301f5f3b2d5a2dc723cbc03d6cc9a47bec6f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-proxy/zipball/cae301f5f3b2d5a2dc723cbc03d6cc9a47bec6f7",
-                "reference": "cae301f5f3b2d5a2dc723cbc03d6cc9a47bec6f7",
-                "shasum": ""
-            },
-            "require": {
-                "drupal/helfi_api_base": "*",
-                "drupal/purge": "^3.0",
-                "drupal/varnish_purge": "^2.1",
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "php": "^8.0"
-            },
-            "conflict": {
-                "drupal/helfi_tunnistamo": "<=2.2.1"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "drupal/coder": "^8.3",
-                "phpspec/prophecy-phpunit": "^2"
-            },
-            "type": "drupal-module",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Provides various fixes so we can serve multiple Drupal instances in one domain.",
-            "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/tree/2.3.0",
-                "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/issues"
-            },
-            "time": "2022-11-08T11:03:23+00:00"
         },
         {
             "name": "drupal/helfi_tpr",

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -52,6 +52,7 @@ module:
   helfi_node_landing_page: 0
   helfi_node_page: 0
   helfi_palvelukeskus_genesys: 0
+  helfi_palvelukeskus_headers: 0
   helfi_paragraphs_accordion: 0
   helfi_paragraphs_banner: 0
   helfi_paragraphs_chart: 0

--- a/public/modules/custom/helfi_palvelukeskus_headers/helfi_palvelukeskus_headers.info.yml
+++ b/public/modules/custom/helfi_palvelukeskus_headers/helfi_palvelukeskus_headers.info.yml
@@ -1,0 +1,5 @@
+name: Palvelukeskus Headers
+type: module
+description: Adds headers to page responses.
+package: Custom
+core_version_requirement: ^9 || ^10

--- a/public/modules/custom/helfi_palvelukeskus_headers/helfi_palvelukeskus_headers.services.yml
+++ b/public/modules/custom/helfi_palvelukeskus_headers/helfi_palvelukeskus_headers.services.yml
@@ -1,0 +1,4 @@
+services:
+  Drupal\helfi_palvelukeskus_headers\EventSubscriber\RobotsResponseSubscriber:
+    tags:
+      - { name: event_subscriber }

--- a/public/modules/custom/helfi_palvelukeskus_headers/src/EventSubscriber/RobotsResponseSubscriber.php
+++ b/public/modules/custom/helfi_palvelukeskus_headers/src/EventSubscriber/RobotsResponseSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_palvelukeskus_headers\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Adds an X-Robots-Tag to response headers.
+ */
+final class RobotsResponseSubscriber implements EventSubscriberInterface {
+
+  public const X_ROBOTS_TAG_HEADER_NAME = 'DRUPAL_X_ROBOTS_TAG_HEADER';
+
+  /**
+   * Adds an X-Robots-Tag response header.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The event to respond to.
+   */
+  public function onResponse(ResponseEvent $event) : void {
+    $response = $event->getResponse();
+
+    if ((bool) getenv(self::X_ROBOTS_TAG_HEADER_NAME)) {
+      $response->headers->add(['X-Robots-Tag' => 'noindex, nofollow']);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    $events[KernelEvents::RESPONSE][] = ['onResponse', -100];
+    return $events;
+  }
+
+}


### PR DESCRIPTION
# [UHF-10255](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10255)

## What was done
* Remove `helfi_proxy` module because it has been uninstalled for a long time
* Add `purge` and `varnish_purge` modules (previously installed as dependencies from `helfi_proxy`)
* Add and enable a new custom module that adds the `X-Robots-Tag: noindex, nofollow` header when `DRUPAL_X_ROBOTS_TAG_HEADER` environment variable is set to true.

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10255-add-noindex-tag`
  * `make fresh`
* Run `make drush-cr`

## How to test
* [ ] Open any page and check that the `x-robots-tag` header is not set.
* Add `DRUPAL_X_ROBOTS_TAG_HEADER: 1` to `compose.yaml` under `services` -> `app` -> `environment`, then run `make up drush-cr`
  * [ ] Reload the page. The header should be set now
* Remove the env variable line from `compose.yaml`, then run `make up drush-cr`
  * [ ] Reload the page. The header should be gone.
* [ ] Check that code follows our standards

## Continuous documentation

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Other PRs
* https://github.com/City-of-Helsinki/helsinki-paatokset/pull/436

[UHF-10255]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ